### PR TITLE
Fix incorrect log message in WindowService.Close

### DIFF
--- a/RedCatEngineUnityProject/Packages/Windows/Services/WindowService.cs
+++ b/RedCatEngineUnityProject/Packages/Windows/Services/WindowService.cs
@@ -62,7 +62,7 @@ namespace RedCatEngine.Windows.Services
 			if (!_windowInfos.TryGetValue(windowConfig, out var info))
 				return;
 
-			_logService.LogFormat("Open window {0}", windowConfig);
+			_logService.LogFormat("Close window {0}", windowConfig.name);
 			info.Close();
 		}
 


### PR DESCRIPTION
### Motivation
- Исправить некорректное лог-сообщение в `Close(WindowConfig windowConfig)`, которое выводило `Open window {0}` и передавало `windowConfig` вместо `windowConfig.name`.

### Description
- В `RedCatEngineUnityProject/Packages/Windows/Services/WindowService.cs` заменил `_logService.LogFormat("Open window {0}", windowConfig);` на `_logService.LogFormat("Close window {0}", windowConfig.name);` и проверил согласованность остальных сообщений `Open`, `Close`, `Close all`.

### Testing
- Выполнены автоматизированные проверки: `rg "Log|LogFormat" RedCatEngineUnityProject/Packages/Windows/Services/WindowService.cs` (успешно), инспекция файла через `nl -ba` (успешно) и фиксация изменения в репозитории через `git commit` (успешно).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ee780c490832ab2c23bed177de031)