### PR TITLE
Throw QueueStateIsEmptyException when entering next state from empty queue

### DIFF
--- a/RedCatEngineUnityProject/Packages/StateMachine/Exceptions/QueueStateIsEmptyException.cs
+++ b/RedCatEngineUnityProject/Packages/StateMachine/Exceptions/QueueStateIsEmptyException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace RedCatEngine.StateMachine.Exceptions
+{
+	public class QueueStateIsEmptyException : Exception
+	{
+		public string StateMachineName;
+
+		public QueueStateIsEmptyException(string stateMachineName)
+			: base(string.Format("Queue is empty in state machine {0}", stateMachineName))
+		{
+			StateMachineName = stateMachineName;
+		}
+	}
+}

--- a/RedCatEngineUnityProject/Packages/StateMachine/Exceptions/QueueStateIsEmptyException.cs.meta
+++ b/RedCatEngineUnityProject/Packages/StateMachine/Exceptions/QueueStateIsEmptyException.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9f91da2944d247dca73f4b3259e13d34
+timeCreated: 1760000000

--- a/RedCatEngineUnityProject/Packages/StateMachine/StateMachines/BaseTypedStateMachine.cs
+++ b/RedCatEngineUnityProject/Packages/StateMachine/StateMachines/BaseTypedStateMachine.cs
@@ -78,6 +78,9 @@ namespace RedCatEngine.StateMachine.StateMachines
 
 		public ITypedQueueStateMachine EnterNextFromQueue()
 		{
+			if (_queue.Count == 0)
+				throw new QueueStateIsEmptyException(_name);
+
 			var data = _queue.Dequeue();
 			AddToHistory(data);
 			var nextState = SelectStateAsActive(data.StateType);

--- a/RedCatEngineUnityProject/Packages/StateMachine/Tests/ExceptionStateMachineTests.cs
+++ b/RedCatEngineUnityProject/Packages/StateMachine/Tests/ExceptionStateMachineTests.cs
@@ -48,5 +48,26 @@ namespace RedCatEngine.StateMachine.Tests
 
 			Assert.IsTrue(false, "Not catch exception");
 		}
+
+		[Test]
+		public void GivenStateMachine_WhenEnterNextFromEmptyQueue_ThenCatchQueueStateIsEmptyException()
+		{
+			try
+			{
+				_stateMachine.EnterNextFromQueue();
+			}
+			catch (Exception exception)
+			{
+				Assert.IsTrue(
+					exception is QueueStateIsEmptyException,
+					"Catch incorrect error");
+				Assert.IsTrue(
+					exception.Message.Contains("TestedTypedStateMachine"),
+					"State machine name is not specified in exception message");
+				return;
+			}
+
+			Assert.IsTrue(false, "Not catch exception");
+		}
 	}
 }


### PR DESCRIPTION
### Motivation
- Prevent calling `Dequeue()` on an empty `_queue` and provide a clear, diagnosable error when `EnterNextFromQueue()` is invoked with no queued states.
- Include the state machine name in the error to simplify troubleshooting which machine raised the condition.

### Description
- Add `QueueStateIsEmptyException` to `Packages/StateMachine/Exceptions` with a `StateMachineName` field and an error message containing the machine name.
- Update `BaseTypedStateMachine.EnterNextFromQueue()` to check `if (_queue.Count == 0)` and throw `QueueStateIsEmptyException(_name)` before calling `Dequeue()`.
- Extend `Packages/StateMachine/Tests/ExceptionStateMachineTests.cs` with `GivenStateMachine_WhenEnterNextFromEmptyQueue_ThenCatchQueueStateIsEmptyException` to assert the new exception type and that the exception message contains the state machine name.

### Testing
- No automated test runner was executed in this environment because the Unity/NUnit test runner is unavailable here, so the new NUnit test was added but not executed.
- A code search for `QueueStateIsEmptyException` and `EnterNextFromQueue(` was run to verify usages and changes were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ee78517ec832a884ee75346aa6d8f)