### PR TITLE
Fix DailyQuestSystem quest replenishment and TestQuestFactory creation

### DIFF
--- a/RedCatEngineUnityProject/Packages/Quests/Mechanics/QuestSystems/DailyQuestSystem.cs
+++ b/RedCatEngineUnityProject/Packages/Quests/Mechanics/QuestSystems/DailyQuestSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using RedCatEngine.Quests.Mechanics.Data;
 using RedCatEngine.Quests.Mechanics.Factories;
 using RedCatEngine.Quests.Mechanics.Quests;
 
@@ -19,6 +20,7 @@ namespace RedCatEngine.Quests.Mechanics.QuestSystems
 		{
 			_countQuests = countQuests;
 			_dailyTimeLiveSeconds = dailyTimeLiveSeconds;
+			LoadData(QuestsDataContainer.Empty);
 		}
 
 		protected override void DoAfterLoadData()
@@ -48,8 +50,11 @@ namespace RedCatEngine.Quests.Mechanics.QuestSystems
 			var toRemove = ActiveQuests.Where(PredicateForRemoveQuests()).ToArray();
 			foreach (var quest in toRemove)
 			{
-				quest.Disable();
 				quest.ChangeQuestStateEvent -= OnChangeQuestState;
+
+				if (quest.QuestState == QuestState.InProgress)
+					quest.Disable();
+
 				ActiveQuests.Remove(quest);
 			}
 

--- a/RedCatEngineUnityProject/Packages/Quests/Tests/SpecialSubClasses/TestQuestData.cs
+++ b/RedCatEngineUnityProject/Packages/Quests/Tests/SpecialSubClasses/TestQuestData.cs
@@ -9,9 +9,19 @@ namespace RedCatEngine.Quests.Tests.SpecialSubClasses
 	[Serializable]
 	public class TestQuestData : IQuestData
 	{
-		public ConfigID<QuestConfig> Config => ConfigID<QuestConfig>.Invalid;
-		public DateTime CreateTime { get; }
-		public QuestState QuestState { get; }
+		private ConfigID<QuestConfig> _config = ConfigID<QuestConfig>.Invalid;
+		private DateTime _createTime = DateTime.UtcNow;
+		private QuestState _questState = QuestState.InProgress;
+
+		public ConfigID<QuestConfig> Config
+			=> _config;
+
+		public DateTime CreateTime
+			=> _createTime;
+
+		public QuestState QuestState
+			=> _questState;
+
 		public ConfigID<QuestConfig> GetConfig()
 		{
 			return Config;
@@ -19,17 +29,17 @@ namespace RedCatEngine.Quests.Tests.SpecialSubClasses
 
 		public DateTime GetCreateTime()
 		{
-			throw new NotImplementedException();
+			return CreateTime;
 		}
 
 		public QuestState GetQuestState()
 		{
-			throw new NotImplementedException();
+			return QuestState;
 		}
 
 		public void SetQuestState(QuestState newQuestState)
 		{
-			throw new NotImplementedException();
+			_questState = newQuestState;
 		}
 
 		public void ConstructSerialization(
@@ -38,7 +48,9 @@ namespace RedCatEngine.Quests.Tests.SpecialSubClasses
 			QuestState questState
 		)
 		{
-			throw new NotImplementedException();
+			_config = config;
+			_createTime = createTime;
+			_questState = questState;
 		}
 	}
 }

--- a/RedCatEngineUnityProject/Packages/Quests/Tests/SpecialSubClasses/TestQuestFactory.cs
+++ b/RedCatEngineUnityProject/Packages/Quests/Tests/SpecialSubClasses/TestQuestFactory.cs
@@ -19,7 +19,7 @@ namespace RedCatEngine.Quests.Tests.SpecialSubClasses
 
 		public IQuest MakeNewQuest(List<IQuest> currentActiveQuests)
 		{
-			throw new System.NotImplementedException();
+			return MakeNewQuest();
 		}
 
 		public IQuest LoadFrom(IQuestData saveData)


### PR DESCRIPTION
### Motivation
- Tests expecting correct active-quest replenishment, removal on skip/finish, and correct load behavior failed due to ActiveQuests not being initialized and removal logic incorrectly forcing state transitions.

### Description
- Initialize `DailyQuestSystem` with `LoadData(QuestsDataContainer.Empty)` in the constructor so the active quest list is populated to the required count at creation. (updated `DailyQuestSystem.cs`)
- Change removal flow in `UpdateQuestList` to unsubscribe from events first and call `Disable()` only when the quest is still `InProgress`, avoiding redundant state transitions for already skipped/finished/failed quests. (updated `DailyQuestSystem.cs`)
- Implement `TestQuestFactory.MakeNewQuest(List<IQuest>)` to delegate to the internal test queue method `MakeNewQuest()` so test factory can supply quests to the system without throwing `NotImplementedException`. (updated `TestQuestFactory.cs`)

### Testing
- No Unity/NUnit tests were executed because a Unity test runner is not available in this environment, so automated tests could not be run here and therefore have no pass/fail result.
- Basic repository checks were performed (`git commit`, `git show`) and succeeded, and the changes were committed as part of a local commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f101d2108832ab2b85c4151e368a4)