### PR TITLE
Split Unity CI into per-package GitHub Actions workflows

### DIFF
--- a/.github/workflows/tests-applicationrunner.yml
+++ b/.github/workflows/tests-applicationrunner.yml
@@ -1,0 +1,71 @@
+name: Tests / ApplicationRunner
+
+on: push
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+  UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+  UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+
+jobs:
+  testRunner:
+    name: Run EditMode tests for ApplicationRunner
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        testMode:
+          - EditMode
+        targetPlatform:
+          - WebGL
+    permissions:
+      checks: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v4
+        id: lfs-cache
+        with:
+          path: .git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+
+      - name: Git LFS Pull
+        run: |
+          git lfs pull
+          git add .
+          git reset --hard
+
+      - name: Restore Library cache
+        uses: actions/cache@v4
+        with:
+          path: RedCatEngineUnityProject/Library
+          key: Library-test-project-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-test-project-
+            Library-
+
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v4.3.0
+        id: testRunner
+        with:
+          unityVersion: 2021.3.31f1
+          projectPath: RedCatEngineUnityProject
+          testMode: ${{ matrix.testMode }}
+          customParameters: -assemblyNames ApplicationRunnerTests
+          checkName: ApplicationRunner test results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ApplicationRunner Test results
+          path: ${{ steps.testRunner.outputs.artifactsPath }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ApplicationRunner Coverage results
+          path: ${{ steps.testRunner.outputs.coveragePath }}

--- a/.github/workflows/tests-benchmark.yml
+++ b/.github/workflows/tests-benchmark.yml
@@ -1,0 +1,71 @@
+name: Tests / Benchmark
+
+on: push
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+  UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+  UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+
+jobs:
+  testRunner:
+    name: Run EditMode tests for Benchmark
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        testMode:
+          - EditMode
+        targetPlatform:
+          - WebGL
+    permissions:
+      checks: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v4
+        id: lfs-cache
+        with:
+          path: .git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+
+      - name: Git LFS Pull
+        run: |
+          git lfs pull
+          git add .
+          git reset --hard
+
+      - name: Restore Library cache
+        uses: actions/cache@v4
+        with:
+          path: RedCatEngineUnityProject/Library
+          key: Library-test-project-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-test-project-
+            Library-
+
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v4.3.0
+        id: testRunner
+        with:
+          unityVersion: 2021.3.31f1
+          projectPath: RedCatEngineUnityProject
+          testMode: ${{ matrix.testMode }}
+          customParameters: -assemblyNames BenchmarkTests
+          checkName: Benchmark test results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Benchmark Test results
+          path: ${{ steps.testRunner.outputs.artifactsPath }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Benchmark Coverage results
+          path: ${{ steps.testRunner.outputs.coveragePath }}

--- a/.github/workflows/tests-conditions.yml
+++ b/.github/workflows/tests-conditions.yml
@@ -1,0 +1,71 @@
+name: Tests / Conditions
+
+on: push
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+  UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+  UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+
+jobs:
+  testRunner:
+    name: Run EditMode tests for Conditions
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        testMode:
+          - EditMode
+        targetPlatform:
+          - WebGL
+    permissions:
+      checks: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v4
+        id: lfs-cache
+        with:
+          path: .git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+
+      - name: Git LFS Pull
+        run: |
+          git lfs pull
+          git add .
+          git reset --hard
+
+      - name: Restore Library cache
+        uses: actions/cache@v4
+        with:
+          path: RedCatEngineUnityProject/Library
+          key: Library-test-project-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-test-project-
+            Library-
+
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v4.3.0
+        id: testRunner
+        with:
+          unityVersion: 2021.3.31f1
+          projectPath: RedCatEngineUnityProject
+          testMode: ${{ matrix.testMode }}
+          customParameters: -assemblyNames ConditionsTests
+          checkName: Conditions test results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Conditions Test results
+          path: ${{ steps.testRunner.outputs.artifactsPath }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Conditions Coverage results
+          path: ${{ steps.testRunner.outputs.coveragePath }}

--- a/.github/workflows/tests-configs.yml
+++ b/.github/workflows/tests-configs.yml
@@ -1,0 +1,71 @@
+name: Tests / Configs
+
+on: push
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+  UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+  UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+
+jobs:
+  testRunner:
+    name: Run EditMode tests for Configs
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        testMode:
+          - EditMode
+        targetPlatform:
+          - WebGL
+    permissions:
+      checks: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v4
+        id: lfs-cache
+        with:
+          path: .git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+
+      - name: Git LFS Pull
+        run: |
+          git lfs pull
+          git add .
+          git reset --hard
+
+      - name: Restore Library cache
+        uses: actions/cache@v4
+        with:
+          path: RedCatEngineUnityProject/Library
+          key: Library-test-project-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-test-project-
+            Library-
+
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v4.3.0
+        id: testRunner
+        with:
+          unityVersion: 2021.3.31f1
+          projectPath: RedCatEngineUnityProject
+          testMode: ${{ matrix.testMode }}
+          customParameters: -assemblyNames ConfigsTests
+          checkName: Configs test results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Configs Test results
+          path: ${{ steps.testRunner.outputs.artifactsPath }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Configs Coverage results
+          path: ${{ steps.testRunner.outputs.coveragePath }}

--- a/.github/workflows/tests-dependencyinjection.yml
+++ b/.github/workflows/tests-dependencyinjection.yml
@@ -1,0 +1,71 @@
+name: Tests / DependencyInjection
+
+on: push
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+  UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+  UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+
+jobs:
+  testRunner:
+    name: Run EditMode tests for DependencyInjection
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        testMode:
+          - EditMode
+        targetPlatform:
+          - WebGL
+    permissions:
+      checks: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v4
+        id: lfs-cache
+        with:
+          path: .git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+
+      - name: Git LFS Pull
+        run: |
+          git lfs pull
+          git add .
+          git reset --hard
+
+      - name: Restore Library cache
+        uses: actions/cache@v4
+        with:
+          path: RedCatEngineUnityProject/Library
+          key: Library-test-project-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-test-project-
+            Library-
+
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v4.3.0
+        id: testRunner
+        with:
+          unityVersion: 2021.3.31f1
+          projectPath: RedCatEngineUnityProject
+          testMode: ${{ matrix.testMode }}
+          customParameters: -assemblyNames DependencyInjectionTests
+          checkName: DependencyInjection test results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: DependencyInjection Test results
+          path: ${{ steps.testRunner.outputs.artifactsPath }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: DependencyInjection Coverage results
+          path: ${{ steps.testRunner.outputs.coveragePath }}

--- a/.github/workflows/tests-gamesettings.yml
+++ b/.github/workflows/tests-gamesettings.yml
@@ -1,0 +1,71 @@
+name: Tests / GameSettings
+
+on: push
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+  UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+  UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+
+jobs:
+  testRunner:
+    name: Run EditMode tests for GameSettings
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        testMode:
+          - EditMode
+        targetPlatform:
+          - WebGL
+    permissions:
+      checks: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v4
+        id: lfs-cache
+        with:
+          path: .git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+
+      - name: Git LFS Pull
+        run: |
+          git lfs pull
+          git add .
+          git reset --hard
+
+      - name: Restore Library cache
+        uses: actions/cache@v4
+        with:
+          path: RedCatEngineUnityProject/Library
+          key: Library-test-project-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-test-project-
+            Library-
+
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v4.3.0
+        id: testRunner
+        with:
+          unityVersion: 2021.3.31f1
+          projectPath: RedCatEngineUnityProject
+          testMode: ${{ matrix.testMode }}
+          customParameters: -assemblyNames GameSettingsTests
+          checkName: GameSettings test results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: GameSettings Test results
+          path: ${{ steps.testRunner.outputs.artifactsPath }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: GameSettings Coverage results
+          path: ${{ steps.testRunner.outputs.coveragePath }}

--- a/.github/workflows/tests-pools.yml
+++ b/.github/workflows/tests-pools.yml
@@ -1,0 +1,71 @@
+name: Tests / Pools
+
+on: push
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+  UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+  UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+
+jobs:
+  testRunner:
+    name: Run EditMode tests for Pools
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        testMode:
+          - EditMode
+        targetPlatform:
+          - WebGL
+    permissions:
+      checks: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v4
+        id: lfs-cache
+        with:
+          path: .git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+
+      - name: Git LFS Pull
+        run: |
+          git lfs pull
+          git add .
+          git reset --hard
+
+      - name: Restore Library cache
+        uses: actions/cache@v4
+        with:
+          path: RedCatEngineUnityProject/Library
+          key: Library-test-project-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-test-project-
+            Library-
+
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v4.3.0
+        id: testRunner
+        with:
+          unityVersion: 2021.3.31f1
+          projectPath: RedCatEngineUnityProject
+          testMode: ${{ matrix.testMode }}
+          customParameters: -assemblyNames PoolsTests
+          checkName: Pools test results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Pools Test results
+          path: ${{ steps.testRunner.outputs.artifactsPath }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Pools Coverage results
+          path: ${{ steps.testRunner.outputs.coveragePath }}

--- a/.github/workflows/tests-quests.yml
+++ b/.github/workflows/tests-quests.yml
@@ -1,0 +1,71 @@
+name: Tests / Quests
+
+on: push
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+  UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+  UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+
+jobs:
+  testRunner:
+    name: Run EditMode tests for Quests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        testMode:
+          - EditMode
+        targetPlatform:
+          - WebGL
+    permissions:
+      checks: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v4
+        id: lfs-cache
+        with:
+          path: .git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+
+      - name: Git LFS Pull
+        run: |
+          git lfs pull
+          git add .
+          git reset --hard
+
+      - name: Restore Library cache
+        uses: actions/cache@v4
+        with:
+          path: RedCatEngineUnityProject/Library
+          key: Library-test-project-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-test-project-
+            Library-
+
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v4.3.0
+        id: testRunner
+        with:
+          unityVersion: 2021.3.31f1
+          projectPath: RedCatEngineUnityProject
+          testMode: ${{ matrix.testMode }}
+          customParameters: -assemblyNames QuestsTests
+          checkName: Quests test results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Quests Test results
+          path: ${{ steps.testRunner.outputs.artifactsPath }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Quests Coverage results
+          path: ${{ steps.testRunner.outputs.coveragePath }}

--- a/.github/workflows/tests-resourcesystem.yml
+++ b/.github/workflows/tests-resourcesystem.yml
@@ -1,0 +1,71 @@
+name: Tests / ResourceSystem
+
+on: push
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+  UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+  UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+
+jobs:
+  testRunner:
+    name: Run EditMode tests for ResourceSystem
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        testMode:
+          - EditMode
+        targetPlatform:
+          - WebGL
+    permissions:
+      checks: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v4
+        id: lfs-cache
+        with:
+          path: .git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+
+      - name: Git LFS Pull
+        run: |
+          git lfs pull
+          git add .
+          git reset --hard
+
+      - name: Restore Library cache
+        uses: actions/cache@v4
+        with:
+          path: RedCatEngineUnityProject/Library
+          key: Library-test-project-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-test-project-
+            Library-
+
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v4.3.0
+        id: testRunner
+        with:
+          unityVersion: 2021.3.31f1
+          projectPath: RedCatEngineUnityProject
+          testMode: ${{ matrix.testMode }}
+          customParameters: -assemblyNames ResourceSystemTests
+          checkName: ResourceSystem test results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ResourceSystem Test results
+          path: ${{ steps.testRunner.outputs.artifactsPath }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ResourceSystem Coverage results
+          path: ${{ steps.testRunner.outputs.coveragePath }}

--- a/.github/workflows/tests-rewards.yml
+++ b/.github/workflows/tests-rewards.yml
@@ -1,0 +1,71 @@
+name: Tests / Rewards
+
+on: push
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+  UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+  UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+
+jobs:
+  testRunner:
+    name: Run EditMode tests for Rewards
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        testMode:
+          - EditMode
+        targetPlatform:
+          - WebGL
+    permissions:
+      checks: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v4
+        id: lfs-cache
+        with:
+          path: .git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+
+      - name: Git LFS Pull
+        run: |
+          git lfs pull
+          git add .
+          git reset --hard
+
+      - name: Restore Library cache
+        uses: actions/cache@v4
+        with:
+          path: RedCatEngineUnityProject/Library
+          key: Library-test-project-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-test-project-
+            Library-
+
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v4.3.0
+        id: testRunner
+        with:
+          unityVersion: 2021.3.31f1
+          projectPath: RedCatEngineUnityProject
+          testMode: ${{ matrix.testMode }}
+          customParameters: -assemblyNames RewardsTests
+          checkName: Rewards test results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Rewards Test results
+          path: ${{ steps.testRunner.outputs.artifactsPath }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Rewards Coverage results
+          path: ${{ steps.testRunner.outputs.coveragePath }}

--- a/.github/workflows/tests-statemachine.yml
+++ b/.github/workflows/tests-statemachine.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Tests / StateMachine
 
 on: push
 
@@ -9,7 +9,7 @@ env:
 
 jobs:
   testRunner:
-    name: Run EditMode tests for all packages
+    name: Run EditMode tests for StateMachine
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -56,15 +56,16 @@ jobs:
           unityVersion: 2021.3.31f1
           projectPath: RedCatEngineUnityProject
           testMode: ${{ matrix.testMode }}
-          checkName: All packages test results
+          customParameters: -assemblyNames StateMachineTests
+          checkName: StateMachine test results
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/upload-artifact@v4
         with:
-          name: Test results
+          name: StateMachine Test results
           path: ${{ steps.testRunner.outputs.artifactsPath }}
 
       - uses: actions/upload-artifact@v4
         with:
-          name: Coverage results
+          name: StateMachine Coverage results
           path: ${{ steps.testRunner.outputs.coveragePath }}

--- a/.github/workflows/tests-universalservices.yml
+++ b/.github/workflows/tests-universalservices.yml
@@ -1,0 +1,71 @@
+name: Tests / UniversalServices
+
+on: push
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+  UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+  UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+
+jobs:
+  testRunner:
+    name: Run EditMode tests for UniversalServices
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        testMode:
+          - EditMode
+        targetPlatform:
+          - WebGL
+    permissions:
+      checks: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v4
+        id: lfs-cache
+        with:
+          path: .git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+
+      - name: Git LFS Pull
+        run: |
+          git lfs pull
+          git add .
+          git reset --hard
+
+      - name: Restore Library cache
+        uses: actions/cache@v4
+        with:
+          path: RedCatEngineUnityProject/Library
+          key: Library-test-project-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-test-project-
+            Library-
+
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v4.3.0
+        id: testRunner
+        with:
+          unityVersion: 2021.3.31f1
+          projectPath: RedCatEngineUnityProject
+          testMode: ${{ matrix.testMode }}
+          customParameters: -assemblyNames UniversalServicesTests
+          checkName: UniversalServices test results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: UniversalServices Test results
+          path: ${{ steps.testRunner.outputs.artifactsPath }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: UniversalServices Coverage results
+          path: ${{ steps.testRunner.outputs.coveragePath }}

--- a/.github/workflows/tests-values.yml
+++ b/.github/workflows/tests-values.yml
@@ -1,0 +1,71 @@
+name: Tests / Values
+
+on: push
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+  UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+  UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+
+jobs:
+  testRunner:
+    name: Run EditMode tests for Values
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        testMode:
+          - EditMode
+        targetPlatform:
+          - WebGL
+    permissions:
+      checks: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v4
+        id: lfs-cache
+        with:
+          path: .git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+
+      - name: Git LFS Pull
+        run: |
+          git lfs pull
+          git add .
+          git reset --hard
+
+      - name: Restore Library cache
+        uses: actions/cache@v4
+        with:
+          path: RedCatEngineUnityProject/Library
+          key: Library-test-project-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-test-project-
+            Library-
+
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v4.3.0
+        id: testRunner
+        with:
+          unityVersion: 2021.3.31f1
+          projectPath: RedCatEngineUnityProject
+          testMode: ${{ matrix.testMode }}
+          customParameters: -assemblyNames ValuesTests
+          checkName: Values test results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Values Test results
+          path: ${{ steps.testRunner.outputs.artifactsPath }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Values Coverage results
+          path: ${{ steps.testRunner.outputs.coveragePath }}

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -1,0 +1,71 @@
+name: Tests / Windows
+
+on: push
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+  UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+  UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+
+jobs:
+  testRunner:
+    name: Run EditMode tests for Windows
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        testMode:
+          - EditMode
+        targetPlatform:
+          - WebGL
+    permissions:
+      checks: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v4
+        id: lfs-cache
+        with:
+          path: .git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+
+      - name: Git LFS Pull
+        run: |
+          git lfs pull
+          git add .
+          git reset --hard
+
+      - name: Restore Library cache
+        uses: actions/cache@v4
+        with:
+          path: RedCatEngineUnityProject/Library
+          key: Library-test-project-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-test-project-
+            Library-
+
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v4.3.0
+        id: testRunner
+        with:
+          unityVersion: 2021.3.31f1
+          projectPath: RedCatEngineUnityProject
+          testMode: ${{ matrix.testMode }}
+          customParameters: -assemblyNames WindowsTests
+          checkName: Windows test results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Windows Test results
+          path: ${{ steps.testRunner.outputs.artifactsPath }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Windows Coverage results
+          path: ${{ steps.testRunner.outputs.coveragePath }}


### PR DESCRIPTION
### Motivation
- Упростить и ускорить CI: вместо одного большого workflow запустить отдельные Actions для каждого пакета, чтобы запускались только релевантные тесты. 
- Сделать результаты и артефакты более удобными для отслеживания за счёт пакет-специфичных названий проверок и артефактов. 
- Автоматически использовать существующие тестовые сборки (`*.asmdef`) каждого пакета для точечной прогонки тестов.

### Description
- Добавлены отдельные workflow-файлы ` .github/workflows/tests-*.yml` для каждого пакета (например, `tests-applicationrunner.yml`, `tests-dependencyinjection.yml`, `tests-gamesettings.yml` и т.д.).
- Каждый workflow сохраняет оригинальную последовательность шагов (checkout, LFS cache/pull, Library cache, `game-ci/unity-test-runner`, загрузка артефактов), но использует `customParameters: -assemblyNames <PackageTestsAssembly>` и пакет-специфичные `checkName`/artifact names, чтобы запускать только нужную тестовую сборку. 
- Генерация workflows выполнена на основе `*.asmdef` файлов в `RedCatEngineUnityProject/Packages/*/Tests/` чтобы соответствовать именам тестовых сборок по пакетам.

### Testing
- Проверена корректность сгенерированных workflow-файлов и наличие строк `customParameters: -assemblyNames` и `checkName` во всех `tests-*.yml` с помощью `rg`/`sed`, и ожидаемые сборки соответствуют `*.asmdef` в пакете. 
- Запуск `git diff --check` не выявил проблем и вернул успешный статус. 
- Выполнен `git status --short` для проверки списка изменённых/добавленных workflow-файлов и он отражает все новые `tests-*.yml` файлы.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f161e0cc0832ab25830833cff4dfb)