### PR TITLE
Add requester type info to DI missing-instance exception

### DIFF
--- a/RedCatEngineUnityProject/Packages/DependencyInjection/Containers/ApplicationContainer.cs
+++ b/RedCatEngineUnityProject/Packages/DependencyInjection/Containers/ApplicationContainer.cs
@@ -205,7 +205,21 @@ namespace RedCatEngine.DependencyInjection.Containers
 				context) && type.IsInstanceOfType(createdInstance))
 				return createdInstance;
 
-			throw new NotFoundInstanceOrCreateException(type);
+			throw new NotFoundInstanceOrCreateException(type, TryGetRequesterTypeFromContext(context));
+		}
+
+		private static Type TryGetRequesterTypeFromContext(object[] context)
+		{
+			foreach (var contextParameter in context)
+			{
+				if (contextParameter is not KeyValuePair<string, Type> requesterContext ||
+					requesterContext.Key != Injector.RequesterTypeContextKey)
+					continue;
+
+				return requesterContext.Value;
+			}
+
+			return null;
 		}
 
 		public TInstanceBindType BindDummy<TInstanceBindType, TDummyType>(params object[] context)

--- a/RedCatEngineUnityProject/Packages/DependencyInjection/Exceptions/NotFoundInstanceOrCreateException.cs
+++ b/RedCatEngineUnityProject/Packages/DependencyInjection/Exceptions/NotFoundInstanceOrCreateException.cs
@@ -5,12 +5,21 @@ namespace RedCatEngine.DependencyInjection.Exceptions
 	public class NotFoundInstanceOrCreateException : Exception
 	{
 		public readonly Type NotFoundType;
+		public readonly Type RequesterType;
 		private const string ErrorMessageFormat = "Not found instances or create for Type {0}";
+		private const string ErrorMessageWithRequesterFormat =
+			"Not found instances or create for Type {0}. Requested by Type {1}";
 
-		public NotFoundInstanceOrCreateException(Type notFoundType)
-			: base(string.Format(ErrorMessageFormat, notFoundType))
+		public NotFoundInstanceOrCreateException(Type notFoundType, Type requesterType = null)
+			: base(string.Format(
+				requesterType == null
+					? ErrorMessageFormat
+					: ErrorMessageWithRequesterFormat,
+				notFoundType,
+				requesterType))
 		{
 			NotFoundType = notFoundType;
+			RequesterType = requesterType;
 		}
 	}
 }

--- a/RedCatEngineUnityProject/Packages/DependencyInjection/Specials/Injector.cs
+++ b/RedCatEngineUnityProject/Packages/DependencyInjection/Specials/Injector.cs
@@ -10,6 +10,8 @@ namespace RedCatEngine.DependencyInjection.Specials
 {
 	public class Injector
 	{
+		public const string RequesterTypeContextKey = "__requester_type_context__";
+
 		private readonly IGetterApplicationContainer _getter;
 		private readonly ProviderService _providerService;
 
@@ -55,6 +57,12 @@ namespace RedCatEngine.DependencyInjection.Specials
 
 		private object[] GetParametersForMethod(MethodBase method, object[] context)
 		{
+			var parameterContext = new object[context.Length + 1];
+			Array.Copy(context, parameterContext, context.Length);
+			parameterContext[context.Length] = new KeyValuePair<string, Type>(
+				RequesterTypeContextKey,
+				method.DeclaringType);
+
 			var parameters = new List<object>();
 
 			foreach (var parameterInfo in method.GetParameters())
@@ -75,7 +83,7 @@ namespace RedCatEngine.DependencyInjection.Specials
 					continue;
 				}
 
-				parameters.Add(_getter.GetSingle(parameterInfo.ParameterType, context));
+				parameters.Add(_getter.GetSingle(parameterInfo.ParameterType, parameterContext));
 			}
 			return parameters.ToArray();
 		}

--- a/RedCatEngineUnityProject/Packages/DependencyInjection/Tests/ExceptionDiContainerTests.cs
+++ b/RedCatEngineUnityProject/Packages/DependencyInjection/Tests/ExceptionDiContainerTests.cs
@@ -49,6 +49,29 @@ namespace RedCatEngine.DependencyInjection.Tests
 		}
 
 		[Test]
+		public void GivenApplicationContainer_WhenInjectNotContainInstance_ThenCatchRequesterTypeInException()
+		{
+			var applicationContainer = new ApplicationContainer();
+			try
+			{
+				applicationContainer.GetSingle<SimpleInjectedDemoParentClass>();
+			}
+			catch (Exception exception)
+			{
+				Assert.IsTrue(exception is NotFoundInstanceOrCreateException, "Incorrect error");
+				Assert.IsTrue(
+					((NotFoundInstanceOrCreateException)exception).NotFoundType == typeof(SimpleDemoFirstDataChildClass),
+					"Incorrect not found type");
+				Assert.IsTrue(
+					((NotFoundInstanceOrCreateException)exception).RequesterType == typeof(SimpleInjectedDemoParentClass),
+					"Incorrect requester type");
+				return;
+			}
+
+			Assert.Fail("Not catch error");
+		}
+
+		[Test]
 		public void GivenApplicationContainer_WhenTryCreateInterface_ThenCatchNotCorrectType()
 		{
 			var applicationContainer = new ApplicationContainer();


### PR DESCRIPTION
### Motivation
- Improve diagnostics when the DI system fails to resolve a dependency by including the type that requested the missing instance in the thrown exception message.

### Description
- Extended `NotFoundInstanceOrCreateException` to store `RequesterType` and include it in the formatted message when available.
- Propagated requester metadata from the `Injector` into the resolve context using `RequesterTypeContextKey` so the container knows which type initiated the parameter resolution.
- Updated `ApplicationContainer.GetSingle` to extract the requester type from the context and pass it into the `NotFoundInstanceOrCreateException` when throwing.
- Added a unit test `GivenApplicationContainer_WhenInjectNotContainInstance_ThenCatchRequesterTypeInException` to validate `RequesterType` is populated on injection failure.

### Testing
- Ran `git diff --check` to validate workspace changes with no whitespace/patch issues and it passed.
- Updated NUnit test coverage in `ExceptionDiContainerTests.cs`, but the Unity/NUnit test runner was not executed in this environment so tests were not run here.
- No automated runtime/unit tests were executed due to lack of a Unity test runner in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997fdb549b4832a811aae6b282c63ee)